### PR TITLE
panel: Add a separator after the clock

### DIFF
--- a/panel/solus.layout
+++ b/panel/solus.layout
@@ -21,13 +21,20 @@ locked=true
 object-type=applet
 applet-iid=NotificationAreaAppletFactory::NotificationArea
 toplevel-id=bottom
-position=20
+position=30
 panel-right-stick=true
 locked=true
 
 [Object clock]
 object-type=applet
 applet-iid=ClockAppletFactory::ClockApplet
+toplevel-id=bottom
+position=10
+panel-right-stick=true
+locked=true
+
+[Object separator]
+object-type=separator
 toplevel-id=bottom
 position=0
 panel-right-stick=true


### PR DESCRIPTION
To fix https://github.com/solus-project/mate-desktop-branding/issues/3

Looks fine with Adapta theme